### PR TITLE
Allow laravel schemaless attributes package reach to higher version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "illuminate/routing": "~5.8.0",
         "illuminate/support": "~5.8.0",
         "illuminate/validation": "~5.8.0",
-        "spatie/laravel-schemaless-attributes": "~1.3.0",
+        "spatie/laravel-schemaless-attributes": "~1.3.0|^1.4",
         "watson/validating": "^3.2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR just add an options for laravel schemaless attributes package reach to higher version. I have compared both version of 1.3.0 and 1.4.0 and it may not occur any further issues for **rinvex/laravel-support**