### PR TITLE
Ability to enable/disable hashing for each  model in any area without any need to enable/disable the whole area

### DIFF
--- a/src/Traits/HashidsTrait.php
+++ b/src/Traits/HashidsTrait.php
@@ -15,8 +15,10 @@ trait HashidsTrait
      */
     public function getRouteKey()
     {
-        return in_array(request()->route('accessarea'), config('cortex.foundation.obscure.areas'))
-            ? Hashids::encode($this->getAttribute($this->getKeyName()), config('cortex.foundation.obscure.rotate') ? random_int(1, 999) : 1)
+        $obscure = property_exists($this,'obscure') && is_array($this->obscure) ? $this->obscure : config('cortex.foundation.obscure');
+
+        return in_array(request()->route('accessarea'), $obscure)
+            ? Hashids::encode($this->getAttribute($this->getKeyName()), random_int(1, 999))
             : $this->getAttribute($this->getRouteKeyName());
     }
 
@@ -29,7 +31,9 @@ trait HashidsTrait
      */
     public function resolveRouteBinding($value)
     {
-        return in_array(request()->route('accessarea'), config('cortex.foundation.obscure.areas'))
+        $obscure = property_exists($this,'obscure') && is_array($this->obscure) ? $this->obscure : config('cortex.foundation.obscure');
+
+        return in_array(request()->route('accessarea'), $obscure)
             ? $this->where($this->getKeyName(), optional(Hashids::decode($value))[0])->first()
             : $this->where($this->getRouteKeyName(), $value)->first();
     }

--- a/src/Traits/HashidsTrait.php
+++ b/src/Traits/HashidsTrait.php
@@ -19,7 +19,6 @@ trait HashidsTrait
 
         return in_array(request()->route('accessarea'), $obscure['areas'])
             ? Hashids::encode($this->getAttribute($this->getKeyName()), $obscure['rotate'] ? random_int(1, 999) : 1)
-
             : $this->getAttribute($this->getRouteKeyName());
     }
 

--- a/src/Traits/HashidsTrait.php
+++ b/src/Traits/HashidsTrait.php
@@ -17,8 +17,10 @@ trait HashidsTrait
     {
         $obscure = property_exists($this,'obscure') && is_array($this->obscure) ? $this->obscure : config('cortex.foundation.obscure');
 
-        return in_array(request()->route('accessarea'), $obscure)
+        return in_array(request()->route('accessarea'), $obscure['areas'])
             ? Hashids::encode($this->getAttribute($this->getKeyName()), random_int(1, 999))
+            ? Hashids::encode($this->getAttribute($this->getKeyName()), $obscure['rotate'] ? random_int(1, 999) : 1)
+
             : $this->getAttribute($this->getRouteKeyName());
     }
 
@@ -33,7 +35,7 @@ trait HashidsTrait
     {
         $obscure = property_exists($this,'obscure') && is_array($this->obscure) ? $this->obscure : config('cortex.foundation.obscure');
 
-        return in_array(request()->route('accessarea'), $obscure)
+        return in_array(request()->route('accessarea'), $obscure['areas'])
             ? $this->where($this->getKeyName(), optional(Hashids::decode($value))[0])->first()
             : $this->where($this->getRouteKeyName(), $value)->first();
     }

--- a/src/Traits/HashidsTrait.php
+++ b/src/Traits/HashidsTrait.php
@@ -18,7 +18,6 @@ trait HashidsTrait
         $obscure = property_exists($this,'obscure') && is_array($this->obscure) ? $this->obscure : config('cortex.foundation.obscure');
 
         return in_array(request()->route('accessarea'), $obscure['areas'])
-            ? Hashids::encode($this->getAttribute($this->getKeyName()), random_int(1, 999))
             ? Hashids::encode($this->getAttribute($this->getKeyName()), $obscure['rotate'] ? random_int(1, 999) : 1)
 
             : $this->getAttribute($this->getRouteKeyName());


### PR DESCRIPTION
When we need to enable hashing for model **X** in a certain area we must add the area to `config('cortex.foundation.obscure')` that mean hashing will apply on all models in the area not only 
 model **X** this is not the best solution also in case we need to disable hashing for model in area added to  `config('cortex.foundation.obscure')`  we won't able to do that so we should make the model itself have the control enable/disable hashing in any area if we need to do that.