### PR TITLE
Update HasTranslations.php

### DIFF
--- a/src/Traits/HasTranslations.php
+++ b/src/Traits/HasTranslations.php
@@ -70,4 +70,15 @@ trait HasTranslations
 
         return array_replace(parent::attributesToArray(), array_combine($keys, $values));
     }
+    
+    /**
+     * Merge new translatable with existing translatable on the model.
+     *
+     * @param  array  $translatable
+     * @return void
+     */
+    public function mergeTranslatable($translatable)
+    {
+        $this->translatable = array_merge($this->translatable, $translatable);
+    }
 }


### PR DESCRIPTION
This method allow merge translatable property from extend class. It works like mergeCasts or mergeFillable methods. Example:
```php
<?php

namespace App\Models;

use Rinvex\Categories\Models\Category as BaseCategory;

class Category extends BaseCategory
{
    /**
     * Create a new Eloquent model instance.
     *
     * @param array $attributes
     */
    public function __construct(array $attributes = [])
    {
        parent::__construct($attributes);

        $this->mergeFillable([
            'meta_title',
            'meta_description',
            'is_active',
            'is_menu',
        ]);

        $this->mergeCasts([
            'is_active' => 'boolean',
            'is_menu' => 'boolean',
        ]);

        $this->mergeTranslatable([
            'meta_title',
            'meta_description',
        ]);
    }
}
```