### PR TITLE
Update composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,6 @@
 
 Install via `composer require rinvex/laravel-support`
 
-
-## Note for Laravel v9
-
-This package requires `felixkiss/uniquewith-validator` dependency, which is not yet compatible with Laravel v9! However as a temporary workaround, add [Laravel Shift](https://github.com/felixkiss/uniquewith-validator/pull/131)'s fork to the `repositories` property of your project root `composer.json`:
-```json
-{
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/laravel-shift/uniquewith-validator.git"
-        }
-    ]
-}
-```
-
 ## Usage
 
 ## Support Helpers

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "illuminate/routing": "^9.0.0 || ^10.0.0",
         "illuminate/support": "^9.0.0 || ^10.0.0",
         "illuminate/validation": "^9.0.0 || ^10.0.0",
-        "felixkiss/uniquewith-validator": "dev-l9-compatibility",
+        "mattvb91/uniquewith-validator": "3.4.3",
         "watson/validating": "^7.0.0",
         "spatie/laravel-schemaless-attributes": "^2.3.0"
     },


### PR DESCRIPTION
replace `"felixkiss/uniquewith-validator": "dev-l9-compatibility"` due to non existant branch with read only repository. The original repo has been abandoned.

Please allow CI runs to make sure this still works properly. Only changes on this is the laravel shift commit + package name + tag

See all changes here: https://github.com/mattvb91/uniquewith-validator/compare/3.4.2...3.4.3